### PR TITLE
Dont generate import and use IContentItem when there are no elements

### DIFF
--- a/lib/generators/delivery/delivery-content-type.generator.ts
+++ b/lib/generators/delivery/delivery-content-type.generator.ts
@@ -308,7 +308,7 @@ export class DeliveryContentTypeGenerator {
     }): string {
         let code = '';   
         
-        const elements = this.getElementsCode({
+        const elementsCode = this.getElementsCode({
             contentTypeObjectMap: data.contentTypeObjectMap,
             contentTypeNameMap: data.contentTypeNameMap,
             contentType: data.contentType,
@@ -320,7 +320,7 @@ export class DeliveryContentTypeGenerator {
             taxonomies: data.taxonomies
         })
 
-        if(elements) { code += `import { IContentItem, Elements } from '${this.deliveryNpmPackageName}';`; }
+        if(elementsCode) { code += `import { IContentItem, Elements } from '${this.deliveryNpmPackageName}';`; }
 
         const importResult = this.getContentTypeImports({
             contentTypeNameMap: data.contentTypeNameMap,
@@ -357,12 +357,27 @@ export class DeliveryContentTypeGenerator {
             typeName = data.contentTypeNameMap(data.contentType);
 
             if (importResult.contentTypeSnippetExtensions.length) {
-                typeExtends = `& ${importResult.contentTypeSnippetExtensions.join(' & ')}`;
+                typeExtends = importResult.contentTypeSnippetExtensions.join(' & ');
             }
         } else if (data.contentTypeSnippet) {
             comment = this.getContentTypeSnippetComment(data.contentTypeSnippet);
             typeName = data.contentTypeSnippetNameMap(data.contentTypeSnippet);
         }
+
+        let typeElements: string = '';
+        if(elementsCode) {
+            typeElements += `IContentItem<{
+  ${elementsCode}
+}>`
+        }
+        if(elementsCode && typeExtends) {
+            typeElements += ' & '
+        }
+        if(typeExtends) {
+            typeElements += typeExtends
+        }
+
+        if(!elementsCode && !typeExtends) { typeElements = '{}'}
 
         code += `
 /**
@@ -370,7 +385,7 @@ export class DeliveryContentTypeGenerator {
 *
 * ${comment}
 */
-export type ${typeName} = ${elements && `IContentItem<{${elements}}>`}${typeExtends};
+export type ${typeName} = ${typeElements};
 `;
         const formatOptions: Options = data.formatOptions
             ? data.formatOptions

--- a/lib/generators/delivery/delivery-content-type.generator.ts
+++ b/lib/generators/delivery/delivery-content-type.generator.ts
@@ -306,7 +306,21 @@ export class DeliveryContentTypeGenerator {
         addTimestamp: boolean;
         formatOptions?: Options;
     }): string {
-        let code = `import { IContentItem, Elements } from '${this.deliveryNpmPackageName}';`;
+        let code = '';   
+        
+        const elements = this.getElementsCode({
+            contentTypeObjectMap: data.contentTypeObjectMap,
+            contentTypeNameMap: data.contentTypeNameMap,
+            contentType: data.contentType,
+            contentTypeSnippet: data.contentTypeSnippet,
+            snippets: data.snippets,
+            elementNameMap: data.elementNameMap,
+            taxonomyNameMap: data.taxonomyNameMap,
+            taxonomyObjectMap: data.taxonomyObjectMap,
+            taxonomies: data.taxonomies
+        })
+
+        if(elements) { code += `import { IContentItem, Elements } from '${this.deliveryNpmPackageName}';`; }
 
         const importResult = this.getContentTypeImports({
             contentTypeNameMap: data.contentTypeNameMap,
@@ -356,19 +370,7 @@ export class DeliveryContentTypeGenerator {
 *
 * ${comment}
 */
-export type ${typeName} = IContentItem<{
-    ${this.getElementsCode({
-        contentTypeObjectMap: data.contentTypeObjectMap,
-        contentTypeNameMap: data.contentTypeNameMap,
-        contentType: data.contentType,
-        contentTypeSnippet: data.contentTypeSnippet,
-        snippets: data.snippets,
-        elementNameMap: data.elementNameMap,
-        taxonomyNameMap: data.taxonomyNameMap,
-        taxonomyObjectMap: data.taxonomyObjectMap,
-        taxonomies: data.taxonomies
-    })}
-}>${typeExtends};
+export type ${typeName} = ${elements && `IContentItem<{${elements}}>`}${typeExtends};
 `;
         const formatOptions: Options = data.formatOptions
             ? data.formatOptions


### PR DESCRIPTION
When you have a content type that consist of only a snippet then the generator creates code that contain lint errors, example below.

With this PR the generation of the first import is removed as well as the Empty IContentItem at the type definition.

![image](https://user-images.githubusercontent.com/50109737/188170430-88672a43-4c94-40e1-8ff8-fcb95ed14f1d.png)

**import { IContentItem, Elements } from '@kontent-ai/delivery-sdk'**
import { GeneralAssetFromBynder } from '../content-type-snippets/generalAssetFromBynder'

/**
 * Generated by '@kontent-ai/model-generator@5.4.1'
 *
 * General - Image
 * Id: 1ce9382a-61fb-59b5-bf6e-8fde093181fa
 * Codename: general_image
 */
export type generalImage = **IContentItem<{}> &** GeneralAssetFromBynder