### PR TITLE
feat: Add managementApiUrl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ await generateModelsAsync({
 - `exportCollections` - Indicates if collections are exported
 - `exportLanguages` - Indicates if languages are exported
 - `exportRoles` - Indicates if roles are exported. * Only available for Enterprise subscription plans
+- `managementApiUrl` - Sets the url of Management API.
 
 ## Example models
 

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -65,6 +65,9 @@ const argv = yargs(process.argv.slice(2))
     .option('sortTaxonomyTerms', {
         description: 'Indicates if taxonomy terms are sorted alphabetically.'
     })
+    .option('managementApiUrl', {
+        description: 'Sets the url of Management API.'
+    })
     .help('h')
     .alias('h', 'help').argv;
 
@@ -102,6 +105,7 @@ const run = async () => {
 
     await generateModelsAsync({
         environmentId: environmentId,
+        managementApiUrl: resolvedArgs.managementApiUrl,
         apiKey: apiKey,
         outputDir: outputDir,
         isEnterpriseSubscription: isEnterpriseSubscription,

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -43,7 +43,8 @@ export async function generateModelsAsync(config: IGenerateModelsConfig): Promis
 
             const managementClient = createManagementClient({
                 environmentId: config.environmentId,
-                apiKey: config.apiKey
+                apiKey: config.apiKey,
+                baseUrl: config.managementApiUrl,
             });
 
             const projectInformation = (await managementClient.environmentInformation().toPromise()).data;
@@ -299,7 +300,6 @@ export async function generateModelsAsync(config: IGenerateModelsConfig): Promis
         } else {
             throw Error(`Unsupported 'sdkType'. Supported values are: delivery, management`);
         }
-
         console.log(green(`\nCompleted`));
     } catch (error) {
         console.log(red(`Failed with error:`));

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -38,6 +38,7 @@ export interface IGenerateModelsConfig {
     isEnterpriseSubscription: boolean;
     sdkType: SdkType;
     apiKey: string;
+    managementApiUrl?: string;
 
     /**
      * Determines what content structure objects are exported.


### PR DESCRIPTION
### Motivation

Sometimes it is useful (or even necessary) to specify a custom Kontent.ai Management API URL. (e.g. when using a proxy, or QA environment). This PR introduces a configuration option (in code only) that makes this possible.

Internal link: [DEVREL-955](https://kontent-ai.atlassian.net/browse/DEVREL-955)
