### PR TITLE
Escape all single quotes, not just the first

### DIFF
--- a/lib/common-helper.ts
+++ b/lib/common-helper.ts
@@ -89,7 +89,7 @@ export class CommonHelper {
     }
 
     escapeNameValue(value: string): string {
-        return value.replace(`'`, `\\'`);
+        return value.replace(/'/g, `\\'`);
     }
 }
 


### PR DESCRIPTION
### Motivation

If a model contains more than one single quote, only the first is escaped. This will escape others.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

1. Create a content model with a name that has two single quotes, e.g. `Template - Category Page - 'Other' Categories`
2. Prior to this fix, running the generator will result in the following error:
   ```
   SyntaxError: ',' expected. (28476:60)
  28474 |                 id: '...',
  28475 |                 externalId: undefined,
> 28476 |                 name: 'Template - Category Page - \'Other' Categories',
        |                                                            ^
  28477 |                 elements: {
   ```
3. Observe that the first quote was escaped, the second was not.
4. After this patch, the model generates as expected.